### PR TITLE
Only install docker on the vagrant vm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN R --vanilla -f /tmp/r-packages.R
 
 # Copy R script to render a manuscript
 RUN mkdir -p /render
-COPY render_manuscript.R /render
+COPY render_manuscript.R /render/
 
 # Set up a working directory
 RUN mkdir -p /source

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,8 +12,9 @@ Vagrant.configure(2) do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
+  # If need be, you can freeze the box_version at, say, "20151119"
   config.vm.box = "ubuntu/trusty64"
-  config.vm.box_version = "20151119"
+  # config.vm.box_version = "20151119"
   config.vm.provider "virtualbox" do |v|
     v.memory = 2048
     v.cpus = 2

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,17 +1,9 @@
 # print start time
 echo "DATE ||| $(date)"
 
-# Variables
-RSTUDIOVERSION='rstudio-server-0.99.792-amd64.deb'
-
-# Add CRAN mirror to apt-get sources
-add-apt-repository "deb https://cran.rstudio.com/bin/linux/ubuntu trusty/"
-apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9
-
 # Swap out default Ubuntu mirror for a hopefully faster one
 sed -i.bak 's/archive.ubuntu.com/mirrors.rit.edu/' /etc/apt/sources.list
 
-# install LaTeX, nodejs, R, and base Haskell
 apt-get update && apt-get install --assume-yes \
     wget
 


### PR DESCRIPTION
- Fix potential COPY error when copying the RMarkdown rendering script
